### PR TITLE
Feature icon size

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ It will be better to use hyphenated attributes instead of camelcase attributes. 
   Default: #37414a
   ```
 
+  - `icon-size`
+
+  Set the timeline item or title icon size.
+  Control the size of the circle or of the image set using `slots="others"`.
+
+  ```
+  Type: string
+  Default: ''
+  ```
+
 
 ### Slots
 

--- a/example/App.vue
+++ b/example/App.vue
@@ -7,9 +7,9 @@
       <timeline-item bg-color="#9dd8e0" font-color="#e166ab">Welcome to the new year!</timeline-item>
       <timeline-item bg-color="#e6b6b0" :hollow="true">My first 100 stars on Github 🎉</timeline-item>
       <timeline-item bg-color="#b0e6d1">keep going</timeline-item>
-      <timeline-item bg-color="#b0e6d1" iSize="sm">icon sm size</timeline-item>
-      <timeline-item bg-color="#b0e6d1" iSize="md">icon md size</timeline-item>
-      <timeline-item bg-color="#b0e6d1" iSize="lg">icon lg size</timeline-item>
+      <timeline-item bg-color="#b0e6d1" icon-size="small">icon small size</timeline-item>
+      <timeline-item bg-color="#b0e6d1" icon-size="medium">icon medium size</timeline-item>
+      <timeline-item bg-color="#b0e6d1" icon-size="large">icon large size</timeline-item>
       <timeline-title bg-color="#f2d7e1">2017</timeline-title>
       <timeline-item>
         <img src="https://user-images.githubusercontent.com/12069729/36057805-80cfc3d2-0e4e-11e8-8851-6fda091ff389.png" class="icon-heart" slot="others">

--- a/example/App.vue
+++ b/example/App.vue
@@ -7,6 +7,9 @@
       <timeline-item bg-color="#9dd8e0" font-color="#e166ab">Welcome to the new year!</timeline-item>
       <timeline-item bg-color="#e6b6b0" :hollow="true">My first 100 stars on Github 🎉</timeline-item>
       <timeline-item bg-color="#b0e6d1">keep going</timeline-item>
+      <timeline-item bg-color="#b0e6d1" iSize="sm">icon sm size</timeline-item>
+      <timeline-item bg-color="#b0e6d1" iSize="md">icon md size</timeline-item>
+      <timeline-item bg-color="#b0e6d1" iSize="lg">icon lg size</timeline-item>
       <timeline-title bg-color="#f2d7e1">2017</timeline-title>
       <timeline-item>
         <img src="https://user-images.githubusercontent.com/12069729/36057805-80cfc3d2-0e4e-11e8-8851-6fda091ff389.png" class="icon-heart" slot="others">

--- a/src/timelineItemBase.vue
+++ b/src/timelineItemBase.vue
@@ -31,7 +31,7 @@
         iconSize: {
             'sm' : {
                 'top': '.28em', 'left': '-34px', 'width': '10px', 'height': '10px'
-            }
+            },
             'md' : {
                 'top': '0em', 'left': '-39.5px', 'height': '20px', 'width': '20px'
             },

--- a/src/timelineItemBase.vue
+++ b/src/timelineItemBase.vue
@@ -15,7 +15,7 @@
         type: Boolean,
         default: false
       },
-      iSize: {
+      iconSize: {
         type: String,
         default: ''
       },
@@ -28,14 +28,14 @@
     data () {
       return {
         slotOthers: false,
-        iconSize: {
-            'sm' : {
+        iconSizeData: {
+            'small' : {
                 'top': '.28em', 'left': '-34px', 'width': '10px', 'height': '10px'
             },
-            'md' : {
+            'medium' : {
                 'top': '0em', 'left': '-39.5px', 'height': '20px', 'width': '20px'
             },
-            'lg' : {
+            'large' : {
                 'top': '-0.5em', 'left': '-44px', 'height': '30px', 'width': '30px'
             }
         }
@@ -44,7 +44,7 @@
 
     computed: {
       circleStyle () {
-        if (!this.bgColor && !this.lineColor && !this.hollow && !this.iSize) return
+        if (!this.bgColor && !this.lineColor && !this.hollow && !this.iconSize) return
         let style = {}
         if (this.bgColor) {
           style = {
@@ -62,9 +62,9 @@
             'background-color': '#fff'
           })
         }
-        if (this.iSize) {
+        if (this.iconSizeData[this.iconSize]) {
           style = Object.assign({}, style,
-            this.iconSize[this.iSize]
+            this.iconSizeData[this.iconSize]
           )
         }
         return style

--- a/src/timelineItemBase.vue
+++ b/src/timelineItemBase.vue
@@ -15,6 +15,10 @@
         type: Boolean,
         default: false
       },
+      iSize: {
+        type: String,
+        default: ''
+      },
       fontColor: {
         type: String,
         default: '#37414a'
@@ -23,13 +27,24 @@
 
     data () {
       return {
-        slotOthers: false
+        slotOthers: false,
+        iconSize: {
+            'sm' : {
+                'top': '.28em', 'left': '-34px', 'width': '10px', 'height': '10px'
+            }
+            'md' : {
+                'top': '0em', 'left': '-39.5px', 'height': '20px', 'width': '20px'
+            },
+            'lg' : {
+                'top': '-0.5em', 'left': '-44px', 'height': '30px', 'width': '30px'
+            }
+        }
       }
     },
 
     computed: {
       circleStyle () {
-        if (!this.bgColor && !this.lineColor && !this.hollow) return
+        if (!this.bgColor && !this.lineColor && !this.hollow && !this.iSize) return
         let style = {}
         if (this.bgColor) {
           style = {
@@ -46,6 +61,11 @@
           style = Object.assign({}, style, {
             'background-color': '#fff'
           })
+        }
+        if (this.iSize) {
+          style = Object.assign({}, style,
+            this.iconSize[this.iSize]
+          )
         }
         return style
       },


### PR DESCRIPTION
Add an iSize props to the timelineItemBase component (so it can be used in the timeline-item and timeline-title), where the possible values are 'sm', 'md' and 'lg', each setting different sizes, empty case uses default values. Increasing flexibility of use and allowing you to make changes at run time.

Ex:

`<timeline-title iSize="lg">2018</timeline-title>`
`<timeline-item iSize="sm">icon sm size</timeline-item>`
`<timeline-item iSize="md">icon md size</timeline-item>`

Of course, feel free to make any changes that you find useful, thanks